### PR TITLE
processor to collate matching logs

### DIFF
--- a/beater/journalbeat.go
+++ b/beater/journalbeat.go
@@ -29,6 +29,8 @@ import (
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/mheese/journalbeat/config"
 	"github.com/mheese/journalbeat/journal"
+
+	_ "github.com/mheese/journalbeat/custom_processors/collate_events"
 )
 
 // Journalbeat is the main Journalbeat struct

--- a/beater/journalbeat.go
+++ b/beater/journalbeat.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mheese/journalbeat/config"
 	"github.com/mheese/journalbeat/journal"
 
-	_ "github.com/mheese/journalbeat/custom_processors/collate_events"
+	"github.com/mheese/journalbeat/custom_processors/collate_events"
 )
 
 // Journalbeat is the main Journalbeat struct
@@ -176,7 +176,7 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 		logp.Err("Failed to connect to the Systemd Journal: %v", err)
 		return nil, err
 	}
-
+	collate_events.Pub = b.Publisher
 	return jb, nil
 }
 

--- a/custom_processors/collate_events/collate_events.go
+++ b/custom_processors/collate_events/collate_events.go
@@ -1,0 +1,144 @@
+package collate_events
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+	p "github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/logp"
+	"fmt"
+	"time"
+)
+
+type eventCounter struct {
+	Count int
+	LastTimestamp time.Time
+}
+
+type collateEvents struct {
+	Interval int
+	Rules map[string]*p.Condition
+	Metrics map[string]*eventCounter
+}
+
+func init() {
+	p.RegisterPlugin("collate_events",newCollateEvents)
+}
+// TODO add config option to specify the rate of messages for interval. eg: 1 event/sec is okay.
+type collateEventsCfg struct {
+	Interval int				`config:"collation_interval_sec"`
+	RulesCfg map[string]*common.Config	`config:"rules"`
+}
+
+func newCollateEvents(c common.Config) (p.Processor, error) {
+
+	cfg := collateEventsCfg{}
+	c.Unpack(&cfg)
+
+	cEvents := collateEvents{
+		Interval:cfg.Interval,
+		Rules:map[string]*p.Condition{},
+		Metrics:map[string]*eventCounter{},
+	}
+
+	// construct a map of rule_id -> conditions
+	for ruleId, ruleCfg := range cfg.RulesCfg {
+		if ruleCfg.HasField("when") {
+			sub, err := ruleCfg.Child("when", -1)
+			if err != nil {
+				return nil, err
+			}
+			condConfig := p.ConditionConfig{}
+			if err := sub.Unpack(&condConfig); err != nil {
+				return nil, err
+			}
+			cond, err := p.NewCondition(&condConfig)
+			if err != nil {
+				return nil, err
+			}
+			cEvents.Rules[ruleId] = cond
+			cEvents.Metrics[ruleId] = &eventCounter{Count:0, LastTimestamp:time.Now()}
+		}
+	}
+	go cEvents.LogAndResetAllMetrics() // start thread that logs.
+	return &cEvents,nil
+}
+
+
+func (f *collateEvents) LogAndResetAllMetrics () {
+
+	tickChannel := time.NewTicker(time.Second * time.Duration(f.Interval)).C
+	quit := make(chan struct{})
+
+	for {
+		select {
+		case <- tickChannel:
+			total := 0
+			logstr := ""
+			for id,m := range f.Metrics {
+				if m.Count > 1 {
+					logstr += fmt.Sprintf(" collate_events.%s=%d", id, m.Count)
+					total += m.Count
+				}
+				m.Count = 0
+				m.LastTimestamp = time.Now()
+			}
+			logp.Info("%d events collated in last %d seconds.%s ", total, f.Interval, logstr)
+		case <- quit:
+			return
+		}
+	}
+}
+
+func (f *collateEvents) Run(event common.MapStr) (common.MapStr, error) {
+
+	logp.LogInit(logp.LOG_INFO, "", false, true, []string{"collate_events"})
+	sendEvent := true
+	for id,r := range f.Rules {
+		if r.Check(event) {
+			// Event matches a rule. Check if an event already matched in collation interval
+			tsStr, err := event.GetValue("@timestamp"); if err != nil {
+				logp.Err("%s",err)
+				break
+			}
+			var ts time.Time
+			switch tsStr.(type) {
+			case common.Time:
+				ts, err = time.Parse(time.RFC3339, tsStr.(common.Time).String()) ; if err != nil { //probably the shittiest line of code to be ever written.
+				logp.Err("%s", err)
+				return event, nil
+			}
+			case time.Time:
+				ts = tsStr.(time.Time)
+			case string:
+				ts, err = time.Parse(time.RFC3339, tsStr.(string)) ; if err != nil {
+				logp.Err("%s", err)
+				return event, nil
+				}
+			default:
+				logp.Err("%s", err)
+				return event, nil
+			}
+
+			if diff := ts.Sub(f.Metrics[id].LastTimestamp); f.Metrics[id].Count < 1 || diff.Nanoseconds() > 1 * 1e9 {
+				f.Metrics[id].Count += 1;
+				f.Metrics[id].LastTimestamp = ts
+			} else {
+				// Dont send the event. A matching event has been already sent in the past second.
+				f.Metrics[id].Count += 1;
+				f.Metrics[id].LastTimestamp = ts
+				sendEvent = false
+				break; // event collated, skip checking other rules..
+			}
+		}
+	}
+
+	if sendEvent {
+		return event, nil
+	} else {
+		return nil,nil
+	}
+
+}
+
+func (f *collateEvents) String() string {
+	return "collate_events= " + fmt.Sprintf("Rules: %+v",f.Rules)
+}

--- a/custom_processors/collate_events/collate_events_test.go
+++ b/custom_processors/collate_events/collate_events_test.go
@@ -42,7 +42,7 @@ func TestCollateEvents(t *testing.T) {
 	yml := []map[string]interface{}{
 		{
 			"collate_events": map[string]interface{}{
-				"collation_interval_sec": 30,
+				"collation_interval_sec": 5,
 				"rules": map[string]interface{}{
 					"rule0":map[string]interface{}{
 						"when": map[string]interface{}{
@@ -103,7 +103,7 @@ func TestCollateEvents(t *testing.T) {
 
 	tm := time.Now()
 	event := common.MapStr{
-		"@timestamp": tm.Format(time.RFC3339),
+		"@realtime_timestamp": tm.UnixNano(),
 		"beat": common.MapStr{
 			"hostname": "mar",
 			"name":     "my-shipper-1",
@@ -126,6 +126,7 @@ func TestCollateEvents(t *testing.T) {
 			},
 		},
 		"type": "process",
+		"message" : "not useful message",
 	}
 
 	processedEvent := processors.Run(event)
@@ -133,7 +134,7 @@ func TestCollateEvents(t *testing.T) {
 
 	// burst of matching events
 	for i := 0; i<10; i++ {
-		event["@timestamp"] = time.Now().Format(time.RFC3339)
+		event["@realtime_timestamp"] = time.Now().UnixNano()
 		processedEvent = processors.Run(event)
 		assert.Equal(t, (common.MapStr)(nil), processedEvent)
 	}
@@ -141,19 +142,18 @@ func TestCollateEvents(t *testing.T) {
 	// matching events at lower pace
 	for i := 0; i<100; i++ {
 		tm = tm.Add(time.Second * 2)
-		event["@timestamp"] = tm.Format(time.RFC3339)
+		event["@realtime_timestamp"] = tm.UnixNano()
 		processedEvent = processors.Run(event)
 		assert.Equal(t, event, processedEvent)
 	}
 
-	event["@timestamp"] = time.Now().Format(time.RFC3339)
+	event["@realtime_timestamp"] = time.Now().UnixNano()
 	processedEvent = processors.Run(event)
 
 	// another burst of matching events
-	for i := 0; i<100000; i++ {
-		event["@timestamp"] = time.Now().Format(time.RFC3339)
+	for i := 0; i<10000; i++ {
+		event["@realtime_timestamp"] = time.Now().UnixNano()
 		processedEvent = processors.Run(event)
 		assert.Equal(t, (common.MapStr)(nil), processedEvent)
 	}
-
 }

--- a/custom_processors/collate_events/collate_events_test.go
+++ b/custom_processors/collate_events/collate_events_test.go
@@ -1,0 +1,159 @@
+package collate_events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+func GetProcessors(t *testing.T, yml []map[string]interface{}) *processors.Processors {
+
+	config := processors.PluginConfig{}
+
+	for _, action := range yml {
+		c := map[string]common.Config{}
+
+		for name, actionYml := range action {
+			actionConfig, err := common.NewConfigFrom(actionYml)
+			assert.Nil(t, err)
+
+			c[name] = *actionConfig
+		}
+		config = append(config, c)
+
+	}
+
+	list, err := processors.New(config)
+	assert.Nil(t, err)
+
+	return list
+
+}
+
+func TestCollateEvents(t *testing.T) {
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"*"})
+	}
+
+	yml := []map[string]interface{}{
+		{
+			"collate_events": map[string]interface{}{
+				"collation_interval_sec": 30,
+				"rules": map[string]interface{}{
+					"rule0":map[string]interface{}{
+						"when": map[string]interface{}{
+							"equals": map[string]string{
+								"type": "process",
+							},
+						},
+					},
+					"rule1" :map[string]interface{}{
+						"when": map[string]interface{}{
+							"and" : []map[string]interface{} {
+								{
+									"contains": map[string]string{
+										"proc.name": "test",
+									},},
+								{
+									"regexp" : map[string]string{
+										"proc.cmdline": "^launchd",
+									},},
+							},
+						},
+					},
+					"rule2" :map[string]interface{}{
+						"when": map[string]interface{}{
+							"or" : []map[string]interface{} {
+								{
+									"contains": map[string]string{
+										"proc.name": "test",
+									},},
+								{
+									"regexp" : map[string]string{
+										"proc.cmdline": "^launchd",
+									},},
+							},
+						},
+					},
+					"rule3" :map[string]interface{}{
+						"when": map[string]interface{}{
+							"and" : []map[string]interface{} {
+								{
+									"contains": map[string]string{
+										"proc.name": "test",
+									},},
+								{
+									"regexp" : map[string]string{
+										"proc.cmdline": "^launchd",
+									},},
+							},
+						},
+					},
+
+				},
+			},
+		},
+	}
+
+	processors := GetProcessors(t, yml)
+
+	tm := time.Now()
+	event := common.MapStr{
+		"@timestamp": tm.Format(time.RFC3339),
+		"beat": common.MapStr{
+			"hostname": "mar",
+			"name":     "my-shipper-1",
+		},
+		"proc": common.MapStr{
+			"cpu": common.MapStr{
+				"start_time": "Jan14",
+				"system":     26027,
+				"total":      79390,
+				"total_p":    0,
+				"user":       53363,
+			},
+			"name":    "test-1",
+			"cmdline": "/sbin/launchd",
+			"mem": common.MapStr{
+				"rss":   11194368,
+				"rss_p": 0,
+				"share": 0,
+				"size":  int64(2555572224),
+			},
+		},
+		"type": "process",
+	}
+
+	processedEvent := processors.Run(event)
+	assert.Equal(t, event, processedEvent)
+
+	// burst of matching events
+	for i := 0; i<10; i++ {
+		event["@timestamp"] = time.Now().Format(time.RFC3339)
+		processedEvent = processors.Run(event)
+		assert.Equal(t, (common.MapStr)(nil), processedEvent)
+	}
+
+	// matching events at lower pace
+	for i := 0; i<100; i++ {
+		tm = tm.Add(time.Second * 2)
+		event["@timestamp"] = tm.Format(time.RFC3339)
+		processedEvent = processors.Run(event)
+		assert.Equal(t, event, processedEvent)
+	}
+
+	event["@timestamp"] = time.Now().Format(time.RFC3339)
+	processedEvent = processors.Run(event)
+
+	// another burst of matching events
+	for i := 0; i<100000; i++ {
+		event["@timestamp"] = time.Now().Format(time.RFC3339)
+		processedEvent = processors.Run(event)
+		assert.Equal(t, (common.MapStr)(nil), processedEvent)
+	}
+
+}


### PR DESCRIPTION
A hacked version of collation processor.

The right way is to contribute this processor in elastic/beats and add it as dependency in vendor. 
Will use this hacked together version until new version of beats is pulled into journalbeat.